### PR TITLE
chore: add DeepWiki badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # What is RudderStack?
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rudderlabs/rudder-sdk-.net)
+
 [RudderStack](https://rudderstack.com/) is a **customer data pipeline** tool for collecting, routing and processing data from your websites, apps, cloud tools, and data warehouse.
 
 More information on RudderStack can be found [here](https://github.com/rudderlabs/rudder-server).


### PR DESCRIPTION
## Description

Add a [DeepWiki](https://deepwiki.com) badge to the top of the README. DeepWiki provides AI-powered documentation and makes it easier for contributors and users to explore and understand the repository.

## Changes

- Added an "Ask DeepWiki" badge to `README.md`, linked to [https://deepwiki.com/rudderlabs/rudder-sdk-.net](https://deepwiki.com/rudderlabs/rudder-sdk-.net)

## Testing

- No functional changes; visual verification that the badge renders correctly in the README.
