### PR TITLE
chore: correct Gzip default version reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Install-Package RudderAnalytics -Version 2.0.1
 
 ## Migrating from v1 to v2
 
-The Gzip feature is enabled by default in the .NET SDK from version `2.0.1`. Refer to [Gzipping requests](#gzipping-requests) section for more details.
+The Gzip feature is enabled by default in the .NET SDK from version `2.0.0`. Refer to [Gzipping requests](#gzipping-requests) section for more details.
 
 ## Initialize the ```Client```
 
@@ -37,7 +37,7 @@ RudderAnalytics.Initialize(
 ## Gzipping requests
 
 
-> The Gzip feature is enabled by default in the .NET SDK from version `2.0.1`.
+> The Gzip feature is enabled by default in the .NET SDK from version `2.0.0`.
 
 
 The .NET SDK automatically gzips requests. However, you can disable this by setting the `gzip` parameter of `RudderConfig` to `false` while initializing the SDK, as shown:


### PR DESCRIPTION
## Purpose

The README stated the Gzip-by-default feature was introduced in `2.0.1`, but it was actually enabled by default starting in `2.0.0` (confirmed via the `2.0.0` tag, where `RudderConfig` already defaults `gzip` to `true`). This was flagged in PR review as inaccurate and misleading for users checking which SDK version they need for Gzip support.

## Approach

Corrected the two README references to the Gzip default version, changing them from `2.0.1` back to `2.0.0`. The "Latest Version" and install instructions elsewhere in the README correctly remain at `2.0.1`.

## Impact

Documentation only — no functional or behavioural change.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Chore / tooling / CI

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings