### PR TITLE
chore(codeowners): set sdk_team as code owners

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "BUG : <Title>"
 labels: bug, open source
-assignees: desusai7
+assignees: []
 ---
 
 **Describe the bug**

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rudderlabs/sdk_team


### PR DESCRIPTION
## Summary

Adds a root `CODEOWNERS` file assigning the whole SDK team (`@rudderlabs/sdk_team`) as default code owners. This repo previously had no `CODEOWNERS`, so PRs did not auto-request reviews from anyone. With this change, every PR auto-requests review from the SDK team and any team member's approval can unblock chore PRs (Dependabot merges, CI fixes). Part of the SDK-5102 rollout across SDK repos; resolves SDK-5113.

## Changes

- New file `CODEOWNERS` at the repo root with a single rule: `* @rudderlabs/sdk_team`.
- `.github/ISSUE_TEMPLATE/bug_report.md`: default assignee replaced with an empty list (was `desusai7`) — GitHub issue assignees only accept individual users, so a team can't be set here; new issues get routed by on-call triage instead.

## Testing

- Verified `@rudderlabs/sdk_team` already has write access on this repo, so GitHub honors it as code owner as soon as this merges — no access changes needed.
- Post-merge check: the next PR should auto-request review from `sdk_team`, and any member's approval should satisfy the code-owner requirement.

## Screenshots

No UI changes in this PR.

## Notes

No breaking changes or migration steps required. Review-routing change only — no code, workflow, or build behavior is affected.
