### PR TITLE
chore: sdk-5339 decommission stale develop branch

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,7 +1,7 @@
 name: Build and Unit Test Checks
 on:
   pull_request:
-    branches: [ master, develop ]
+    branches: [ master ]
     types: ['opened', 'reopened', 'synchronize']
     paths-ignore:
     - 'README.md'

--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -2,7 +2,7 @@ name: Check PR title
 
 on:
   pull_request:
-    branches: ['develop', 'master']
+    branches: ['master']
     types: ['opened', 'reopened', 'edited', 'synchronize']
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install-Package RudderAnalytics -Version 2.0.2
 
 ## Migrating from v1 to v2
 
-The Gzip feature is enabled by default in the .NET SDK from version `2.0.1`. Refer to [Gzipping requests](#gzipping-requests) section for more details.
+The Gzip feature is enabled by default in the .NET SDK from version `2.0.0`. Refer to [Gzipping requests](#gzipping-requests) section for more details.
 
 ## Initialize the ```Client```
 
@@ -41,7 +41,7 @@ RudderAnalytics.Initialize(
 ## Gzipping requests
 
 
-> The Gzip feature is enabled by default in the .NET SDK from version `2.0.1`.
+> The Gzip feature is enabled by default in the .NET SDK from version `2.0.0`.
 
 
 The .NET SDK automatically gzips requests. However, you can disable this by setting the `gzip` parameter of `RudderConfig` to `false` while initializing the SDK, as shown:


### PR DESCRIPTION
## Summary

- backport the develop-only Gzip documentation correction to `master`
- remove `develop` from build and PR-title workflow triggers
- prepare the repository to delete the stale `develop` branch after merge

## Verification

- confirmed no open pull requests target `develop`
- confirmed the README correction is patch-equivalent to the unique change from PR #36
- validated the modified workflow files as YAML
- confirmed no remaining `develop` references exist in `.github`, `README.md`, or `RELEASING.md`

## Linear

- [SDK-5339](https://linear.app/rudderstack/issue/SDK-5339/decommission-the-stale-develop-branch-in-the-net-sdk-repository)